### PR TITLE
Load function statically

### DIFF
--- a/duplicate-menu.php
+++ b/duplicate-menu.php
@@ -98,7 +98,7 @@ class DuplicateMenu {
         return $new_id;
     }
 
-    function options_screen() {
+    static function options_screen() {
         $nav_menus = wp_get_nav_menus();
     ?>
     <div class="wrap">


### PR DESCRIPTION
Suppress notice caused by this with `WP_DEBUG` on. Load function statically. 
