### PR TITLE
Changed required capability from manage_options to edit_theme_options

### DIFF
--- a/duplicate-menu.php
+++ b/duplicate-menu.php
@@ -31,7 +31,7 @@ define( 'DUPLICATE_MENU_DIR',       plugin_dir_path( __FILE__ ) );
 define( 'DUPLICATE_MENU_URL',       plugin_dir_url( __FILE__ ) );
 
 function duplicate_menu_options_page() {
-    add_theme_page( 'Duplicate Menu', 'Duplicate Menu', 'manage_options', 'duplicate-menu', array( 'DuplicateMenu', 'options_screen' ) );
+    add_theme_page( 'Duplicate Menu', 'Duplicate Menu', 'edit_theme_options', 'duplicate-menu', array( 'DuplicateMenu', 'options_screen' ) );
 }
 
 add_action( 'admin_menu', 'duplicate_menu_options_page' );


### PR DESCRIPTION
I think to edit the menu (in this case duplicate it) a more appropriate capability would be edit_theme_options, as this does the following:

    Allows access to Administration Panel options:
      * Appearance > Widgets
      * Appearance > Menus
      * Appearance > Customize if they are supported by the current theme
      * Appearance > Background
      * Appearance > Header
(see https://codex.wordpress.org/Roles_and_Capabilities#edit_theme_options)